### PR TITLE
fix bug of train & edit_video

### DIFF
--- a/training/coaches/coach.py
+++ b/training/coaches/coach.py
@@ -26,7 +26,11 @@ class Coach:
         if hyperparameters.first_inv_type == 'e4e':
             self.e4e_inversion_net = initialize_e4e_wplus()
 
-        self.e4e_image_transform = transforms.Resize((256, 256))
+        self.e4e_image_transform = transforms.Compose([
+            transforms.ToPILImage(),
+            transforms.Resize((256, 256)),
+            transforms.ToTensor(),
+        ])
 
         # Initialize loss
         self.lpips_loss = LPIPS(net=hyperparameters.lpips_type).to(global_config.device).eval()


### PR DESCRIPTION
1.Fix bug of type dismatch for `transform.Resize()` in training part.
The original code would results in ```TypeError: img should be PIL Image. Got <class 'torch.Tensor'>```.
I replace the `Resize`  op with `F.interpolate` when the image was still a `Tensor` so do not need to convert type TWICE.

2.Fix bug of  Normalize for `transform.normalize` in `edit_video.py`.
